### PR TITLE
add check vmwaretools status

### DIFF
--- a/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
+++ b/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
@@ -45,6 +45,7 @@
     password: "{{ molecule_yml.driver.vcenter_password }}"
     validate_certs: "{{ molecule_yml.driver.validate_certs | default(false) }}"
     datacenter: "{{ molecule_yml.driver.datacenter }}"
+    folder: "{{ molecule_yml.driver.folder }}"
     name: "{{ item.name }}"
   register: guest_state
   until: "guest_state.instance.guest_tools_status == 'guestToolsRunning'"

--- a/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
+++ b/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
@@ -38,6 +38,21 @@
   delay: 10
   retries: 300
 
+- name: Check vmware tools status
+  vmware_guest_info:
+    hostname: "{{ molecule_yml.driver.vcenter_hostname }}"
+    username: "{{ molecule_yml.driver.vcenter_username }}"
+    password: "{{ molecule_yml.driver.vcenter_password }}"
+    validate_certs: "{{ molecule_yml.driver.validate_certs | default(false) }}"
+    datacenter: "{{ molecule_yml.driver.datacenter }}"
+    name: "{{ item.name }}"
+  register: guest_state
+  until: "guest_state.instance.guest_tools_status == 'guestToolsRunning'"
+  delay: 10
+  retries: 300
+  loop: "{{ molecule_yml.platforms }}"
+  ignore_errors: true
+
 - name: Enable WinRM
   vmware_vm_shell:
     hostname: "{{ molecule_yml.driver.vcenter_hostname }}"


### PR DESCRIPTION
vmware_vm_shell実行時に、vmware_toolsが起動してないと正常に稼働しなかったので
VM作成後にvmware_toolsの状態確認taskを追加しました。

私の環境に依存しているかもしれませんので、環境情報をお伝えします。

HW: Nutanix NX-1065-G5
vCSA: 6.5
ESXi: 6.0
WindowsTemplate: 2016