### PR TITLE
Fix unsupported parameter error has been occurring in creation a windows instance

### DIFF
--- a/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
+++ b/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
@@ -17,7 +17,8 @@
     networks: "{{ item.networks }}"
     customization:
       hostname: "{{ item.name }}"
-      autlogon: false
+      autologon: false
+      autologoncount: 1
       fullname: "{{ item.customization.fullname | default('molecule') }}"
       orgname: "{{ item.customization.orgname | default('molecule') }}"
       password: "{{ molecule_yml.driver.vm_password }}"


### PR DESCRIPTION
##### SUMMARY

This PR will fix the unsupported parameter error that has been occurring in the creation of a windows instance.  
fixes: https://github.com/sky-joker/molecule-vmware/issues/11

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml

##### ADDITIONAL INFORMATION