### PR TITLE
add login option to the driver.py

### DIFF
--- a/molecule_vmware/driver.py
+++ b/molecule_vmware/driver.py
@@ -22,6 +22,12 @@ class VMware(Driver):
     @property
     def default_safe_files(self):
         return [self.instance_config]
+    
+    @property
+    def login_cmd_template(self):
+        return (
+            "ssh {address} -l {user} -p {port} -i {identity_file}"
+        )		
 
     @property
     def default_ssh_connection_options(self):

--- a/molecule_vmware/driver.py
+++ b/molecule_vmware/driver.py
@@ -27,7 +27,7 @@ class VMware(Driver):
     def login_cmd_template(self):
         return (
             "ssh {address} -l {user} -p {port} -i {identity_file}"
-        )		
+        )
 
     @property
     def default_ssh_connection_options(self):

--- a/molecule_vmware/driver.py
+++ b/molecule_vmware/driver.py
@@ -22,7 +22,7 @@ class VMware(Driver):
     @property
     def default_safe_files(self):
         return [self.instance_config]
-    
+
     @property
     def login_cmd_template(self):
         return (


### PR DESCRIPTION
Without this fix a "molecule login -h XXXX" will fail with

```
Traceback (most recent call last):
  File "/opt/venv/bin/molecule", line 8, in <module>
    sys.exit(main())
  File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/opt/venv/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/venv/lib/python3.8/site-packages/molecule/command/login.py", line 169, in login
    base.execute_subcommand(scenario.config, subcommand)
  File "/opt/venv/lib/python3.8/site-packages/molecule/command/base.py", line 144, in execute_subcommand
    return command(config).execute()
  File "/opt/venv/lib/python3.8/site-packages/molecule/logger.py", line 185, in wrapper
    rt = func(*args, **kwargs)
  File "/opt/venv/lib/python3.8/site-packages/molecule/command/login.py", line 101, in execute
    self._get_login(hostname)
  File "/opt/venv/lib/python3.8/site-packages/molecule/command/login.py", line 144, in _get_login
    login_cmd = self._config.driver.login_cmd_template.format(**login_options)
AttributeError: 'NoneType' object has no attribute 'format'	
```

Works on my machine ;)