### PR TITLE
add resource pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ platforms:
   - name: instance2
     template: CentOS8
     snapshot_src: linked_clone # is a snapshot name to be possible specified if you want to use linked clone.
-	resource_pool: rpool # is a resource pool to be possible specified
+    resource_pool: rpool # is a resource pool to be possible specified
     hardware:
       num_cpus: 2
       memory_mb: 2048

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ platforms:
   - name: instance2
     template: CentOS8
     snapshot_src: linked_clone # is a snapshot name to be possible specified if you want to use linked clone.
+	resource_pool: rpool # is a resource pool to be possible specified
     hardware:
       num_cpus: 2
       memory_mb: 2048

--- a/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_linux_instance.yml
+++ b/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_linux_instance.yml
@@ -22,6 +22,7 @@
     snapshot_src: "{{ item.snapshot_src | default(omit) }}"
     hardware: "{{ item.hardware | default(omit) }}"
     networks: "{{ item.networks }}"
+    resource_pool: "{{ item.resource_pool | default(omit) }}"
     customization:
       hostname: "{{ item.name }}"
       password: "{{ molecule_yml.driver.vm_password }}"

--- a/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
+++ b/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create_windows_instance.yml
@@ -15,6 +15,7 @@
     snapshot_src: "{{ item.snapshot_src | default(omit) }}"
     hardware: "{{ item.hardware | default(omit) }}"
     networks: "{{ item.networks }}"
+    resource_pool: "{{ item.resource_pool | default(omit) }}"
     customization:
       hostname: "{{ item.name }}"
       autologon: false

--- a/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule_vmware/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -26,6 +26,7 @@ driver:
 platforms:
   - name: instance # is an instance name
     template: change me to template name # is to be used as a template when cloning an instance
+    #resource_pool: change me to resource pool
     #snapshot_src: change me to snapshot name # is a snapshot name to be possible specified if you want to use linked clone.
     hardware:
       num_cpus: 2 # is cpu number to be configured to an instance


### PR DESCRIPTION
This way you can deploy to a predefined resource pool. This is important to restrict teams of provisioning too much at a time.